### PR TITLE
Add Type Hints as specified in is-charms-contributing-guide

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,9 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      chaos-app-label: app.kubernetes.io/name=indico
-      chaos-enabled: false
-      chaos-experiments: pod-delete
       load-test-enabled: false
       load-test-run-args: "-e LOAD_TEST_HOST=localhost"
       zap-before-command: "curl -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,15 @@ line_length = 99
 profile = "black"
 
 [tool.mypy]
-ignore_missing_imports = true
+check_untyped_defs = true
+disallow_untyped_defs = true
 explicit_package_bases = true
+ignore_missing_imports = true
 namespace_packages = true
+
+[[tool.mypy.overrides]]
+disallow_untyped_defs = false
+module = "tests.*"
 
 [tool.pylint]
 disable = "wrong-import-order"

--- a/src/charm.py
+++ b/src/charm.py
@@ -14,8 +14,10 @@ https://discourse.charmhub.io/t/4208
 """
 
 import logging
+import typing
 
 import ops
+from ops import pebble
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
@@ -26,7 +28,7 @@ VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 class IsCharmsTemplateCharm(ops.CharmBase):
     """Charm the service."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: typing.Any):
         """Construct.
 
         Args:
@@ -36,7 +38,7 @@ class IsCharmsTemplateCharm(ops.CharmBase):
         self.framework.observe(self.on.httpbin_pebble_ready, self._on_httpbin_pebble_ready)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
-    def _on_httpbin_pebble_ready(self, event: ops.PebbleReadyEvent):
+    def _on_httpbin_pebble_ready(self, event: ops.PebbleReadyEvent) -> None:
         """Define and start a workload using the Pebble API.
 
         Change this example to suit your needs. You'll need to specify the right entrypoint and
@@ -57,7 +59,7 @@ class IsCharmsTemplateCharm(ops.CharmBase):
         # https://juju.is/docs/sdk/constructs#heading--statuses
         self.unit.status = ops.ActiveStatus()
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent):
+    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
         """Handle changed configuration.
 
         Change this example to suit your needs. If you don't need to handle config, you can remove
@@ -92,7 +94,7 @@ class IsCharmsTemplateCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("invalid log level: '{log_level}'")
 
     @property
-    def _pebble_layer(self):
+    def _pebble_layer(self) -> typing.Union[pebble.LayerDict]:
         """Return a dictionary representing a Pebble layer."""
         return {
             "summary": "httpbin layer",

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,7 @@ class IsCharmsTemplateCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("invalid log level: '{log_level}'")
 
     @property
-    def _pebble_layer(self) -> typing.Union[pebble.LayerDict]:
+    def _pebble_layer(self) -> pebble.LayerDict:
         """Return a dictionary representing a Pebble layer."""
         return {
             "summary": "httpbin layer",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add the type hints that are specified in the [is-charms-contributing-guide](https://github.com/canonical/is-charms-contributing-guide/blob/main/CONTRIBUTING.md#type-hints).

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
