### PR TITLE
Use self-hosted runner by default

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,3 +18,5 @@ jobs:
       zap-rules-file-name: "zap_rules.tsv"
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,3 +7,6 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    with:
+      self-hosted-runner: true
+      self-hosted-runner-label: "edge"


### PR DESCRIPTION
### Overview

Use self-hosted runner by default

### Rationale

Encourage the use of self-hosted runners to ensure better testing of self-hosted runners.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
