### PR TITLE
Revert "Use 2.9/edge juju-channel"

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,8 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      # Use edge due to https://bugs.launchpad.net/juju/+bug/2058506 (will be fixed in 2.9.48)
-      juju-channel: 2.9/edge
       load-test-enabled: false
       load-test-run-args: "-e LOAD_TEST_HOST=localhost"
       zap-before-command: "curl -H \"Host: indico.local\" http://localhost/bootstrap --data-raw 'csrf_token=00000000-0000-0000-0000-000000000000&first_name=admin&last_name=admin&email=admin%40admin.com&username=admin&password=lunarlobster&confirm_password=lunarlobster&affiliation=Canonical'"


### PR DESCRIPTION
### Overview

This reverts commit 9870acbddb0345fa02118d33737e35dd07cdc511.

### Rationale

juju `2.9.49` has been released and the corresponding [bug](https://bugs.launchpad.net/juju/+bug/2058506) should be fixed.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
