### PR TITLE
Add template docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,47 @@ Use links instead.
 -->
 
 # is-charms-template
+<!-- Use this space for badges -->
 
-Charmhub package name: operator-template
-More information: https://charmhub.io/is-charms-template
+<!--Describe your charm in 1-2 sentences. Include the software that the charm deploys (if applicable), and the substrate (VM/K8s).-->
 
-Describe your charm in one or two sentences.
+<!-- If this is a bundle, list its components.-->
 
-## Other resources
+<!--Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. For Charmed {Name}, this includes:
+list or summary of app-specific features-->
 
-<!-- If your charm is documented somewhere else other than Charmhub, provide a link separately. -->
+For information about how to deploy, integrate, and manage this charm, see the Official [is-charms-template Documentation](external link).
 
-- [Read more](https://example.com)
+## Get started
+<!--Briefly summarize what the user will achieve in this guide.-->
 
-- [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+<!--Indicate software and hardware prerequisites-->
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+### (Optional) Set up
+<!--Steps for setting up the environment (e.g. via Multipass).-->
+
+### (Optional) Deploy
+<!--Steps for deploying the charm.-->
+
+### Basic operations
+<!--Brief walkthrough of performing standard configurations or operations-->
+
+<!--(Optional) Link to the `charmcraft.yaml` file-->
+
+## (Optional) Integrations
+<!-- Information about particularly relevant interfaces, endpoints or libraries related to the charm. For example, peer relation endpoints required by other charms for integration.--> 
+
+## Learn more
+* <!--Link to the charm's official documentation-->
+* <!--Link to any developer documentation-->
+* <!--(Optional) Link to official webpage/blog/marketing content--> 
+* <!--(Optional) Link to a page or section about troubleshooting/FAQ-->
+
+## Project and community
+* <!--Link to GitHub issues (if applicable)-->
+* <!--Link to Launchpad (if applicable)-->
+* <!--Link to any contribution guides--> 
+* <!--Link to contact info (if applicable), e.g. Matrix channel--> 
+
+## (Optional) Licensing and trademark
+

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Use links instead.
 # is-charms-template
 <!-- Use this space for badges -->
 
-<!--Describe your charm in 1-2 sentences. Include the software that the charm deploys (if applicable), and the substrate (VM/K8s).-->
+Describe your charm in 1-2 sentences. Include the software that the charm deploys (if applicable), and the substrate (VM/K8s)
 
-<!-- If this is a bundle, list its components.-->
+If this is a bundle, list its components.
 
-<!--Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. For Charmed {Name}, this includes:
-list or summary of app-specific features-->
+Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. For Charmed {Name}, this includes:
+* list or summary of app-specific features
 
 For information about how to deploy, integrate, and manage this charm, see the Official [is-charms-template Documentation](external link).
 
@@ -40,16 +40,16 @@ For information about how to deploy, integrate, and manage this charm, see the O
 <!-- Information about particularly relevant interfaces, endpoints or libraries related to the charm. For example, peer relation endpoints required by other charms for integration.--> 
 
 ## Learn more
-* <!--Link to the charm's official documentation-->
-* <!--Link to any developer documentation-->
-* <!--(Optional) Link to official webpage/blog/marketing content--> 
-* <!--(Optional) Link to a page or section about troubleshooting/FAQ-->
+* [Read more]() <!--Link to the charm's official documentation-->
+* [Developer documentation]() <!--Link to any developer documentation-->
+* [Official webpage]() <!--(Optional) Link to official webpage/blog/marketing content--> 
+* [Troubleshooting]() <!--(Optional) Link to a page or section about troubleshooting/FAQ-->
 
 ## Project and community
-* <!--Link to GitHub issues (if applicable)-->
-* <!--Link to Launchpad (if applicable)-->
-* <!--Link to any contribution guides--> 
-* <!--Link to contact info (if applicable), e.g. Matrix channel--> 
+* [Issues]() <!--Link to GitHub issues (if applicable)-->
+* [Contributing]() <!--Link to any contribution guides--> 
+* [Matrix]() <!--Link to contact info (if applicable), e.g. Matrix channel-->
+* [Launchpad]() <!--Link to Launchpad (if applicable)-->
 
 ## (Optional) Licensing and trademark
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Use links instead.
 # is-charms-template
 <!-- Use this space for badges -->
 
-Describe your charm in 1-2 sentences. Include the software that the charm deploys (if applicable), and the substrate (VM/K8s)
-
-If this is a bundle, list its components.
+Describe your charm in 1-2 sentences. Include the software that the charm deploys (if applicable), and the substrate (VM/K8s).
 
 Like any Juju charm, this charm supports one-line deployment, configuration, integration, scaling, and more. For Charmed {Name}, this includes:
 * list or summary of app-specific features

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -40,7 +40,7 @@ They are published to [Charmhub](https://charmhub.io/), the official repository 
 
 ## Containers
 
-Configuration files for the containers can be found in the respective directories that define the rocks, see the section above.
+Configuration files for the containers can be found in the respective directories that define the rocks.
 
 <!--
 ### Container example
@@ -50,81 +50,49 @@ Description of container.
 The workload that this container is running is defined in the [<container-name> rock](link to rock).
 -->
 
-
 ## Metrics
 Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
 
-### NGINX Prometheus exporter
+<!--
+### Metrics example
 
-Inside the NGINX container, the  [NGINX Prometheus Exporter](https://github.com/nginxinc/nginx-prometheus-exporter) runs to provide statistics on web traffic.
+Description of metric. In what container is the metric run? What statistics or values does the metric provide? 
 
-It is started with `-nginx.scrape-uri=http://localhost:9080/stub_status` , which has been configured in the NGINX container to return NGINX's [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html). 
-The exporter listens on port `9113` and metrics about web traffic to the pod can be scraped by Prometheus there.
+How is the container started? 
 
-### StatsD Prometheus exporter
+On what port(s) does the metric listen?
 
-Inside the Indico container, the [StatsD exporter](https://github.com/prometheus/statsd_exporter) runs to collect [statistics](https://uwsgi-docs.readthedocs.io/en/latest/PushingStats.html) from uWSGI runs.
-
-The `StatsD Prometheus Exporter` listens on ports:
-
-- `9125`: UDP address on which to receive statsd metric.
-- `9102`: expose the web interface and generated Prometheus metrics. The metrics can be scraped by Prometheus here.
-
-### Celery Prometheus exporter
-
-Inside the Indico container, the  [Celery Exporter](https://github.com/danihodovic/celery-exporter) runs to collect metrics from Celery.
-
-The `Celery Exporter` is started with:
-
-- `--broker-url=`: scrape metrics from the Redis (broker) container.
-- `--retry-interval=5`: retry after 5 seconds in case of errors communicating with the broker.
-
-Since Indico Celery serializers are set to work with [Pickle](https://docs.python.org/3/library/pickle.html) instead of [JSON](https://www.json.org/), the environment variable `CE_ACCEPT_CONTENT` is set to `"json,pickle"` so the exporter will be able to read the data.
-
-The `Celery Exporter` listens on port `9808` and metrics about Indico Celery tasks can be scraped there by Prometheus.
-
-The Grafana dashboard is the same available [here](https://grafana.com/grafana/dashboards/17508-celery-tasks-by-task/).
+The workload that this container is running is defined in the [<container-name> rock](link to rock).
+-->
  
 ## Juju events
 
 For this charm, the following Juju events are observed:
 
-1. [<container name>_pebble_ready](https://juju.is/docs/sdk/container-name-pebble-ready-event): fired on Kubernetes charms when the requested container is ready.
-Action: wait for the integrations, and configure the containers.
-2. [config_changed](https://juju.is/docs/sdk/config-changed-event): usually fired in response to a configuration change using the CLI.
-Action: wait for the integrations, validate the configuration, update Ingress, and restart the containers.
-3. [database_relation_joined](https://github.com/canonical/ops-lib-pgsql): for when the PostgreSQL relation has been joined.
-Action: if the unit is the leader, add the extensions [`pg_trgm:public`](https://www.postgresql.org/docs/current/pgtrgm.html) and [`unaccent:public`](https://www.postgresql.org/docs/current/unaccent.html).
-4. [leader_elected](https://juju.is/docs/sdk/leader-elected-event): is emitted for a unit that is elected as leader.
-Action: guarantee that all Indico workers have the same [secret key](https://docs.getindico.io/en/latest/config/settings/?highlight=secret_key#SECRET_KEY) that is used to sign tokens in URLs and select a unit to run Celery.
-5. [master_changed](https://github.com/canonical/ops-lib-pgsql): PostgreSQLClient custom event for when the connection details to the master database on this relation change.
-Action: Update the database connection string configuration and emit config_changed event.
-6. [redis_relation_changed](https://github.com/canonical/redis-k8s-operator): Fired when Redis is changed (host, for example).
-Action: Same as config_changed.
-7. [refresh_external_resources_action](https://charmhub.io/indico/actions): fired when refresh-external-resources action is executed.
-8. [indico_peers_relation_departed](https://juju.is/docs/sdk/relation-name-relation-departed-event): fired when a Indico unit departs. Action: elect a new unit to run Celery on if the departed unit was running Celery and replans the services accordingly.
+<!--
+Numbered list of Juju events. Link to describe the event in more detail (either in Juju docs or in a specific charm's docs). When is the event fired? What does the event indicate/mean?
+-->
 
 > See more in the Juju docs: [Event](https://juju.is/docs/sdk/event)
 
 ## Charm code overview
 
-The `src/charm.py` is the default entry point for a charm and has the IndicoOperatorCharm Python class which inherits from CharmBase.
+The `src/charm.py` is the default entry point for a charm and has the <relevant-charm-class> Python class which inherits from CharmBase. CharmBase is the base class 
+from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
 
-CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
-
-See more information in [Charm](https://juju.is/docs/sdk/constructs#heading--charm).
+> See more in the Juju docs: [Charm](https://juju.is/docs/sdk/constructs#heading--charm)
 
 The `__init__` method guarantees that the charm observes all events relevant to its operation and handles them.
 
 Take, for example, when a configuration is changed by using the CLI.
 
-1. User runs the command
+1. User runs the configuration command:
 ```bash
-juju config indico_no_reply_email=sample@domain.com
+juju config <relevant-charm-configuration>
 ```
-2. A `config-changed` event is emitted
+2. A `config-changed` event is emitted.
 3. In the `__init__` method is defined how to handle this event like this:
 ```python
 self.framework.observe(self.on.config_changed, self._on_config_changed)
 ```
-4. The method `_on_config_changed`, for its turn,  will take the necessary actions such as waiting for all the relations to be ready and then configuring the containers.
+4. The method `_on_config_changed`, for its turn, will take the necessary actions such as waiting for all the relations to be ready and then configuring the containers.

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -1,5 +1,11 @@
 # Charm architecture
 
+<!-- Add overview material here:
+1) What kind of application is it? What kind of software does it use?
+2) Describe Pebble services
+-->
+
+<!-- Example: Indico
 At its core, [Indico](https://getindico.io/) is a [Flask](https://flask.palletsprojects.com/) application that integrates with [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/), and [Celery](https://docs.celeryq.dev/en/stable/).
 
 The charm design leverages the [sidecar](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers) pattern to allow multiple containers in each pod with [Pebble](https://juju.is/docs/sdk/pebble) running as the workload container’s entrypoint.
@@ -22,39 +28,28 @@ indico-0                         3/3     Running   0         6h4m
 This shows there are 4 containers - the three named above, as well as a container for the charm code itself.
 
 And if you run `kubectl describe pod indico-0`, all the containers will have as Command ```/charm/bin/pebble```. That's because Pebble is responsible for the processes startup as explained above.
+-->
 
 ## OCI images
 
-We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) to build OCI Images for Indico and NGINX. 
-The images are defined in [NGINX rock](https://github.com/canonical/indico-operator/tree/main/nginx_rock/) and [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
+We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) to build OCI Images for <charm-name>. 
+The images are defined in [<charm-name> rock](link to rock).
 They are published to [Charmhub](https://charmhub.io/), the official repository of charms.
-This is done by publishing a resource to Charmhub as described in the [Juju SDK How-to guides](https://juju.is/docs/sdk/publishing).
+
+> See more: [How to publish your charm on Charmhub](https://juju.is/docs/sdk/publishing)
 
 ## Containers
 
 Configuration files for the containers can be found in the respective directories that define the rocks, see the section above.
 
-### NGINX
+<!--
+### Container example
 
-This container is the entry point for all web traffic to the pod (on port `8080`). Serves some static files directly and forwards non-static requests to the Indico container (on port `8081`).
+Description of container.
 
-The reason for that is since NGINX provides cache static content, reverse proxy, and load balance among multiple application servers, as well as other features it can be used in front of uWSGI server to significantly reduce server and network load.
+The workload that this container is running is defined in the [<container-name> rock](link to rock).
+-->
 
-The workload that this container is running is defined in the [NGINX rock](https://github.com/canonical/indico-operator/tree/main/nginx_rock/).
-
-### Indico
-
-Indico is a Flask application run by the uWSGI server, one of the most popular servers for these applications.
-
-The uWSGI server is started in HTTP mode (port `8081`) serving Indico Application so NGINX can forward non-static traffic to it.
-
-The workload that this container is running is defined in the [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
-
-### Celery
-
-The Celery is used to process tasks asynchronously created by the Indico application such as sending e-mails, survey notifications, event reminders, etc.
-
-Celery runs in the same container as the Indico container, as defined in the [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
 
 ## Metrics
 Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -1,9 +1,9 @@
 # Charm architecture
 
-<!-- Add overview material here:
+Add overview material here:
 1) What kind of application is it? What kind of software does it use?
-2) Describe Pebble services
--->
+2) Describe Pebble services.
+3) Include an architecture diagram.
 
 <!-- Example: Indico
 At its core, [Indico](https://getindico.io/) is a [Flask](https://flask.palletsprojects.com/) application that integrates with [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/), and [Celery](https://docs.celeryq.dev/en/stable/).

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -51,7 +51,13 @@ The workload that this container is running is defined in the [<container-name> 
 -->
 
 ## Metrics
-Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
+<! --
+Add a description of the metrics:
+* Are there metrics for containers, non-containerised workloads, snaps, or something else?
+* How are the metrics defined or added?
+
+For example, if the charm uses containers: Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
+-->
 
 <!--
 ### Metrics example

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -38,7 +38,7 @@ They are published to [Charmhub](https://charmhub.io/), the official repository 
 
 > See more: [How to publish your charm on Charmhub](https://juju.is/docs/sdk/publishing)
 
-## Containers
+## (Optional) Containers
 
 Configuration files for the containers can be found in the respective directories that define the rocks.
 

--- a/docs-template/explanation/charm-architecture.md
+++ b/docs-template/explanation/charm-architecture.md
@@ -1,0 +1,135 @@
+# Charm architecture
+
+At its core, [Indico](https://getindico.io/) is a [Flask](https://flask.palletsprojects.com/) application that integrates with [PostgreSQL](https://www.postgresql.org/), [Redis](https://redis.io/), and [Celery](https://docs.celeryq.dev/en/stable/).
+
+The charm design leverages the [sidecar](https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers) pattern to allow multiple containers in each pod with [Pebble](https://juju.is/docs/sdk/pebble) running as the workload container’s entrypoint.
+
+Pebble is a lightweight, API-driven process supervisor that is responsible for configuring processes to run in a container and controlling those processes throughout the workload lifecycle.
+
+Pebble `services` are configured through [layers](https://github.com/canonical/pebble#layer-specification), and the following containers represent each one a layer forming the effective Pebble configuration, or `plan`:
+
+1. An [NGINX](https://www.nginx.com/) container, which can be used to efficiently serve static resources, as well as be the incoming point for all web traffic to the pod.
+2. The [Indico](https://getindico.io/) container itself, which has a [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) server configured in HTTP mode.
+
+
+As a result, if you run a `kubectl get pods` on a namespace named for the Juju model you've deployed the Indico charm into, you'll see something like the following:
+
+```bash
+NAME                             READY   STATUS    RESTARTS   AGE
+indico-0                         3/3     Running   0         6h4m
+```
+
+This shows there are 4 containers - the three named above, as well as a container for the charm code itself.
+
+And if you run `kubectl describe pod indico-0`, all the containers will have as Command ```/charm/bin/pebble```. That's because Pebble is responsible for the processes startup as explained above.
+
+## OCI images
+
+We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) to build OCI Images for Indico and NGINX. 
+The images are defined in [NGINX rock](https://github.com/canonical/indico-operator/tree/main/nginx_rock/) and [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
+They are published to [Charmhub](https://charmhub.io/), the official repository of charms.
+This is done by publishing a resource to Charmhub as described in the [Juju SDK How-to guides](https://juju.is/docs/sdk/publishing).
+
+## Containers
+
+Configuration files for the containers can be found in the respective directories that define the rocks, see the section above.
+
+### NGINX
+
+This container is the entry point for all web traffic to the pod (on port `8080`). Serves some static files directly and forwards non-static requests to the Indico container (on port `8081`).
+
+The reason for that is since NGINX provides cache static content, reverse proxy, and load balance among multiple application servers, as well as other features it can be used in front of uWSGI server to significantly reduce server and network load.
+
+The workload that this container is running is defined in the [NGINX rock](https://github.com/canonical/indico-operator/tree/main/nginx_rock/).
+
+### Indico
+
+Indico is a Flask application run by the uWSGI server, one of the most popular servers for these applications.
+
+The uWSGI server is started in HTTP mode (port `8081`) serving Indico Application so NGINX can forward non-static traffic to it.
+
+The workload that this container is running is defined in the [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
+
+### Celery
+
+The Celery is used to process tasks asynchronously created by the Indico application such as sending e-mails, survey notifications, event reminders, etc.
+
+Celery runs in the same container as the Indico container, as defined in the [Indico rock](https://github.com/canonical/indico-operator/tree/main/indico_rock).
+
+## Metrics
+Inside the above mentioned containers, additional Pebble layers are defined in order to provide metrics.
+
+### NGINX Prometheus exporter
+
+Inside the NGINX container, the  [NGINX Prometheus Exporter](https://github.com/nginxinc/nginx-prometheus-exporter) runs to provide statistics on web traffic.
+
+It is started with `-nginx.scrape-uri=http://localhost:9080/stub_status` , which has been configured in the NGINX container to return NGINX's [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html). 
+The exporter listens on port `9113` and metrics about web traffic to the pod can be scraped by Prometheus there.
+
+### StatsD Prometheus exporter
+
+Inside the Indico container, the [StatsD exporter](https://github.com/prometheus/statsd_exporter) runs to collect [statistics](https://uwsgi-docs.readthedocs.io/en/latest/PushingStats.html) from uWSGI runs.
+
+The `StatsD Prometheus Exporter` listens on ports:
+
+- `9125`: UDP address on which to receive statsd metric.
+- `9102`: expose the web interface and generated Prometheus metrics. The metrics can be scraped by Prometheus here.
+
+### Celery Prometheus exporter
+
+Inside the Indico container, the  [Celery Exporter](https://github.com/danihodovic/celery-exporter) runs to collect metrics from Celery.
+
+The `Celery Exporter` is started with:
+
+- `--broker-url=`: scrape metrics from the Redis (broker) container.
+- `--retry-interval=5`: retry after 5 seconds in case of errors communicating with the broker.
+
+Since Indico Celery serializers are set to work with [Pickle](https://docs.python.org/3/library/pickle.html) instead of [JSON](https://www.json.org/), the environment variable `CE_ACCEPT_CONTENT` is set to `"json,pickle"` so the exporter will be able to read the data.
+
+The `Celery Exporter` listens on port `9808` and metrics about Indico Celery tasks can be scraped there by Prometheus.
+
+The Grafana dashboard is the same available [here](https://grafana.com/grafana/dashboards/17508-celery-tasks-by-task/).
+ 
+## Juju events
+
+For this charm, the following Juju events are observed:
+
+1. [<container name>_pebble_ready](https://juju.is/docs/sdk/container-name-pebble-ready-event): fired on Kubernetes charms when the requested container is ready.
+Action: wait for the integrations, and configure the containers.
+2. [config_changed](https://juju.is/docs/sdk/config-changed-event): usually fired in response to a configuration change using the CLI.
+Action: wait for the integrations, validate the configuration, update Ingress, and restart the containers.
+3. [database_relation_joined](https://github.com/canonical/ops-lib-pgsql): for when the PostgreSQL relation has been joined.
+Action: if the unit is the leader, add the extensions [`pg_trgm:public`](https://www.postgresql.org/docs/current/pgtrgm.html) and [`unaccent:public`](https://www.postgresql.org/docs/current/unaccent.html).
+4. [leader_elected](https://juju.is/docs/sdk/leader-elected-event): is emitted for a unit that is elected as leader.
+Action: guarantee that all Indico workers have the same [secret key](https://docs.getindico.io/en/latest/config/settings/?highlight=secret_key#SECRET_KEY) that is used to sign tokens in URLs and select a unit to run Celery.
+5. [master_changed](https://github.com/canonical/ops-lib-pgsql): PostgreSQLClient custom event for when the connection details to the master database on this relation change.
+Action: Update the database connection string configuration and emit config_changed event.
+6. [redis_relation_changed](https://github.com/canonical/redis-k8s-operator): Fired when Redis is changed (host, for example).
+Action: Same as config_changed.
+7. [refresh_external_resources_action](https://charmhub.io/indico/actions): fired when refresh-external-resources action is executed.
+8. [indico_peers_relation_departed](https://juju.is/docs/sdk/relation-name-relation-departed-event): fired when a Indico unit departs. Action: elect a new unit to run Celery on if the departed unit was running Celery and replans the services accordingly.
+
+> See more in the Juju docs: [Event](https://juju.is/docs/sdk/event)
+
+## Charm code overview
+
+The `src/charm.py` is the default entry point for a charm and has the IndicoOperatorCharm Python class which inherits from CharmBase.
+
+CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops) (Python framework for developing charms).
+
+See more information in [Charm](https://juju.is/docs/sdk/constructs#heading--charm).
+
+The `__init__` method guarantees that the charm observes all events relevant to its operation and handles them.
+
+Take, for example, when a configuration is changed by using the CLI.
+
+1. User runs the command
+```bash
+juju config indico_no_reply_email=sample@domain.com
+```
+2. A `config-changed` event is emitted
+3. In the `__init__` method is defined how to handle this event like this:
+```python
+self.framework.observe(self.on.config_changed, self._on_config_changed)
+```
+4. The method `_on_config_changed`, for its turn,  will take the necessary actions such as waiting for all the relations to be ready and then configuring the containers.

--- a/docs-template/index.md
+++ b/docs-template/index.md
@@ -16,7 +16,7 @@ The <charm-name> charm allows for deployment on many different Kubernetes platfo
 
 <!-- Finally, a paragraph that describes whom the product is useful for. -->
 
-This charm will make operating < Charm software > simple and straightforward for DevOps or SRE teams through Juju's clean interface. 
+This charm will make operating <charm-software> simple and straightforward for DevOps or SRE teams through Juju's clean interface. 
 
 ## In this documentation
 

--- a/docs-template/reference/actions.md
+++ b/docs-template/reference/actions.md
@@ -1,0 +1,5 @@
+# Actions
+
+See [Actions](link to actions page).
+
+> Read more about actions in the Juju docs: [Action](https://juju.is/docs/juju/action)

--- a/docs-template/reference/configurations.md
+++ b/docs-template/reference/configurations.md
@@ -1,0 +1,5 @@
+# Configurations
+
+See [Configurations](link to configurations page).
+
+> Read more about configurations in the Juju docs: [Configuration](https://juju.is/docs/juju/configuration)

--- a/docs-template/reference/integrations.md
+++ b/docs-template/reference/integrations.md
@@ -1,0 +1,16 @@
+# Integrations
+
+<!-- Use the template below to add information about integrations supported by this charm. -->
+
+### Integration example
+
+_Interface_:   
+_Supported charms_: 
+
+Description here.
+
+Example <integration-name> integrate command: 
+
+```
+juju integrate <charm-name> <supported-charm>:<integration-name>
+```


### PR DESCRIPTION
Applicable spec (for README template): [DOC009](https://docs.google.com/document/d/1hWd5omP8MVANjh1z9mtQsiiliUZmNar6UrL8mb4Bba0/edit?usp=sharing)

### Overview

Small changes to the index.md template doc. New template docs for common reference and explanation pages. Update the README to follow the template from the technical authors team (currently under review).

### Rationale

- index.md: Fix a temp variable for consistency with the other temp variables in the document.
- Reference: Added an Actions, Configurations, and Integrations template documents. The Actions and Configurations pages will only need an updated link for the relevant charm's information, while the Integrations page will only be used if the charm has integrations. 
- Explanation (ISD-2210): Added a "Charm architecture" template document. Some example text still remains from the Indico version of that page. Some sections (such as an Integrations section) have been removed.
- README (ISD-2058 and ISD-2027): Updated the README template to include the information suggested by the template in DOC009 (under review; feedback is welcome). 

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
