### PR TITLE
Fix license validation

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,6 +1,6 @@
 header:
   license:
-    renovate/ops-2.xspdx-id: Apache-2.0
+    spdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
     content: |
       Copyright [year] [owner]

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,10 +1,13 @@
 header:
   license:
-    spdx-id: Apache-2.0
+    renovate/ops-2.xspdx-id: Apache-2.0
     copyright-owner: Canonical Ltd.
     content: |
       Copyright [year] [owner]
       See LICENSE file for licensing details.
+    pattern: |
+        Copyright \d{4} Canonical Ltd.
+        See LICENSE file for licensing details.
   paths:
     - '**'
   paths-ignore:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix license validation so that the year doesn't have to be updated.

Tested in https://github.com/canonical/pollen-operator/actions/runs/13052493540/job/36415714526?pr=62

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The changelog is updated.

<!-- Explanation for any unchecked items above -->
